### PR TITLE
(Fortran) Implement more literal constants

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
@@ -504,6 +504,11 @@ void Build(const parser::Name &x, SgExpression* &expr)
    std::cout << "Rose::builder::Build(Name)\n";
 }
 
+void Build(const parser::NamedConstant &x, SgExpression* &expr)
+{
+   std::cout << "Rose::builder::Build(NamedConstant)\n";
+}
+
 void Build(const parser::Expr &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(Expr)\n";
@@ -542,52 +547,80 @@ void Build(const parser::LiteralConstant &x, SgExpression* &expr)
 }
 
    // LiteralConstant
-template<typename T>
-void Build(const parser::HollerithLiteralConstant &x, T* &expr)
+void Build(const parser::HollerithLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(HollerithLiteralConstant)\n";
 }
 
-template<typename T>
-void Build(const parser::IntLiteralConstant &x, T* &expr)
+void Build(const parser::IntLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(IntLiteralConstant)\n";
 
    expr = SageBuilderCpp17::buildIntVal_nfi(stoi(std::get<0>(x.t).ToString()));
 }
 
-template<typename T>
-void Build(const parser::RealLiteralConstant &x, T* &expr)
+void Build(const parser::SignedIntLiteralConstant &x, SgExpression* &expr)
+{
+   std::cout << "Rose::builder::Build(SignedIntLiteralConstant)\n";
+   // std::tuple<CharBlock, std::optional<KindParam>> t;
+
+   expr = SageBuilderCpp17::buildIntVal_nfi(stoi(std::get<0>(x.t).ToString()));
+}
+
+void Build(const parser::RealLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(RealLiteralConstant)\n";
+
+   expr = SageBuilderCpp17::buildFloatVal_nfi(x.real.source.ToString());
 }
 
-template<typename T>
-void Build(const parser::ComplexLiteralConstant &x, T* &expr)
+void Build(const parser::SignedRealLiteralConstant &x, SgExpression* &expr)
+{
+   std::cout << "Rose::builder::Build(SignedRealLiteralConstant)\n";
+   // std::tuple<std::optional<Sign>, RealLiteralConstant> t;
+
+   Build(std::get<1>(x.t), expr);
+}
+
+void Build(const parser::ComplexLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(ComplexLiteralConstant)\n";
+   // std::tuple<ComplexPart, ComplexPart> t;
+
+   SgExpression * real_value = nullptr, * imaginary_value = nullptr;
+
+   Build(std::get<0>(x.t), real_value);
+   Build(std::get<1>(x.t), imaginary_value);
+
+   expr = SageBuilderCpp17::buildComplexVal_nfi(real_value, imaginary_value, "");
 }
 
-template<typename T>
-void Build(const parser::BOZLiteralConstant &x, T* &expr)
+void Build(const parser::BOZLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(BOZLiteralConstant)\n";
 }
 
-template<typename T>
-void Build(const parser::CharLiteralConstant &x, T* &expr)
+void Build(const parser::CharLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(CharLiteralConstant)\n";
-   std::string literal = x.GetString();
-   std::cout << " The CHAR LITERAL CONSTANT is \"" << literal << "\"" << std::endl;
+
+   expr = SageBuilderCpp17::buildStringVal_nfi(x.GetString());
 }
 
-template<typename T>
-void Build(const parser::LogicalLiteralConstant &x, T* &expr)
+void Build(const parser::LogicalLiteralConstant &x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(LogicalLiteralConstant)\n";
-   bool literal = std::get<0>(x.t);
-   std::cout << " The LOGICAL LITERAL CONSTANT is " << literal << std::endl;
+
+   expr = SageBuilderCpp17::buildBoolValExp_nfi(std::get<0>(x.t));
+}
+
+void Build(const parser::ComplexPart &x, SgExpression* &expr)
+{
+   std::cout << "Rose::builder::Build(ComplexPart)\n";
+   // std::variant<SignedIntLiteralConstant, SignedRealLiteralConstant, NamedConstant>
+
+   auto ComplexPartVisitor = [&](const auto& y) { Build(y, expr); };
+   std::visit(ComplexPartVisitor, x.u);
 }
 
 template<typename T>

--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
@@ -46,18 +46,23 @@ void Build(const Fortran::parser::         ActualArgSpec &x, SgExpression* &expr
 void Build(const Fortran::parser::             ActualArg &x, SgExpression* &expr);
 void Build(const Fortran::parser::               Keyword &x, SgExpression* &expr);
 void Build(const Fortran::parser::                  Name &x, SgExpression* &expr);
+void Build(const Fortran::parser::         NamedConstant &x, SgExpression* &expr);
 void Build(const Fortran::parser::                  Expr &x, SgExpression* &expr);
 void Build(const Fortran::parser:: Expr::IntrinsicBinary &x, SgExpression* &expr);
 void Build(const Fortran::parser::       LiteralConstant &x, SgExpression* &expr);
 
 // LiteralConstant
-template<typename T> void Build(const Fortran::parser::HollerithLiteralConstant &x, T* &expr);
-template<typename T> void Build(const Fortran::parser::     IntLiteralConstant &x, T* &expr);
-template<typename T> void Build(const Fortran::parser::    RealLiteralConstant &x, T* &expr);
-template<typename T> void Build(const Fortran::parser:: ComplexLiteralConstant &x, T* &expr);
-template<typename T> void Build(const Fortran::parser::     BOZLiteralConstant &x, T* &expr);
-template<typename T> void Build(const Fortran::parser::    CharLiteralConstant &x, T* &expr);
-template<typename T> void Build(const Fortran::parser:: LogicalLiteralConstant &x, T* &expr);
+void Build(const Fortran::parser:: HollerithLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::       IntLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser:: SignedIntLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::      RealLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::SignedRealLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::   ComplexLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::       BOZLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::      CharLiteralConstant &x, SgExpression* &expr);
+void Build(const Fortran::parser::   LogicalLiteralConstant &x, SgExpression* &expr);
+
+void Build(const Fortran::parser::ComplexPart &x, SgExpression* &expr);
 
 template<typename T> void Build(const Fortran::parser::InternalSubprogramPart &x, T* scope);
 template<typename T> void Build(const Fortran::parser::          ImplicitPart &x, T* scope);

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
@@ -1201,6 +1201,17 @@ SgExpression* buildFloatVal_nfi(const std::string &str)
    return SageBuilder::buildFloatVal_nfi(str);
 }
 
+SgExpression* buildComplexVal_nfi(SgExpression* real_value, SgExpression* imaginary_value, const std::string &str)
+{
+   SgValueExp* real = isSgValueExp(real_value);
+   SgValueExp* imaginary = isSgValueExp(imaginary_value);
+
+   //   ROSE_ASSERT(real);
+   //   ROSE_ASSERT(imaginary);
+
+   return SageBuilder::buildComplexVal_nfi(real, imaginary, str);
+}
+
 SgExpression* buildVarRefExp_nfi(std::string &name, SgScopeStatement* scope)
 {
    SgVarRefExp* var_ref = SageBuilder::buildVarRefExp(name, scope);

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
@@ -237,6 +237,7 @@ namespace SageBuilderCpp17 {
    SgExpression*  buildIntVal_nfi(int);
    SgExpression*  buildStringVal_nfi(std::string);
    SgExpression*  buildFloatVal_nfi(const std::string &);
+   SgExpression*  buildComplexVal_nfi(SgExpression* real_value, SgExpression* imaginary_value, const std::string &str);
    SgExpression*  buildExprListExp_nfi();
    SgExpression*  buildVarRefExp_nfi(std::string &name, SgScopeStatement* scope = NULL);
    SgExpression*  buildSubtractOp_nfi(SgExpression* lhs, SgExpression* rhs);


### PR DESCRIPTION
In sage-build.h and sage-build.cc, I implemented
SignedIntLiteralConstant, SignedRealLiteralConstant,
RealLiteralConstant, ComplexLiteralConstant,
CharLiteralConstant, LogicalLiteralConstant

In sage-tree-builder.h and sage-tree-builder.C, I implemented
another wrapper function in SageBuilderCpp17, buildComplexVal()