### PR TITLE
(Fortran) Implemented ArrayConstructor

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
@@ -1449,10 +1449,38 @@ void Build(const parser::CharLiteralConstantSubstring&x, T* &expr)
    std::cout << "Rose::builder::Build(CharLiteralConstantSubstring)\n";
 }
 
-template<typename T>
-void Build(const parser::ArrayConstructor&x, T* &expr)
+void Build(const parser::ArrayConstructor&x, SgExpression* &expr)
 {
    std::cout << "Rose::builder::Build(ArrayConstructor)\n";
+
+   Build(x.v, expr);
+}
+
+void Build(const parser::AcSpec&x, SgExpression* &expr)
+{
+   std::cout << "Rose::builder::Build(AcSpec)\n";
+   //  std::optional<TypeSpec> type;
+   //  std::list<AcValue> values;
+
+   std::list<SgExpression*> acvalue_list;
+
+   Build(x.values, acvalue_list);
+
+   SgExprListExp* initializers = SageBuilderCpp17::buildExprListExp_nfi(acvalue_list);
+   expr = SageBuilderCpp17::buildAggregateInitializer_nfi(initializers);
+}
+
+void Build(const parser::AcValue&x, SgExpression* &expr)
+{
+   std::cout << "Rose::builder::Build(AcValue)\n";
+   //  std::variant<Triplet, common::Indirection<Expr>, common::Indirection<AcImpliedDo>> u;
+
+   std::visit(
+      common::visitors{
+         [&](const common::Indirection<parser::Expr>  &y) { Build(y.value(), expr); },
+         [&](const auto &y) { ; },
+      },
+      x.u);
 }
 
 template<typename T>

--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
@@ -187,7 +187,9 @@ template<typename T> void Build(const Fortran::parser::     OldParameterStmt &x,
 template<typename T> void traverseBinaryExprs(const T &x, SgExpression* &lhs, SgExpression* &rhs);
 
 template<typename T> void Build(const Fortran::parser::CharLiteralConstantSubstring &x, T* &expr);
-template<typename T> void Build(const Fortran::parser::            ArrayConstructor &x, T* &expr);
+void Build(const Fortran::parser::            ArrayConstructor &x, SgExpression* &expr);
+void Build(const Fortran::parser::                      AcSpec &x, SgExpression* &expr);
+void Build(const Fortran::parser::                     AcValue &x, SgExpression* &expr);
 template<typename T> void Build(const Fortran::parser::        StructureConstructor &x, T* &expr);
 template<typename T> void Build(const Fortran::parser::         Expr::DefinedBinary &x, T* &expr);
 template<typename T> void Build(const Fortran::parser::    Expr::ComplexConstructor &x, T* &expr);

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
@@ -1230,6 +1230,11 @@ SgExpression* buildPntrArrRefExp_nfi(SgExpression* lhs, SgExpression* rhs)
    return SageBuilder::buildPntrArrRefExp_nfi(lhs, rhs);
 }
 
+SgExpression* buildAggregateInitializer_nfi(SgExprListExp* initializers, SgType* type)
+{
+   return SageBuilder::buildAggregateInitializer_nfi(initializers, type);
+}
+
 SgExpression* buildAsteriskShapeExp_nfi()
 {
    SgAsteriskShapeExp* shape = new SgAsteriskShapeExp();

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
@@ -243,6 +243,7 @@ namespace SageBuilderCpp17 {
    SgExpression*  buildSubtractOp_nfi(SgExpression* lhs, SgExpression* rhs);
    SgExpression*  buildSubscriptExpression_nfi(SgExpression* lower_bound, SgExpression* upper_bound, SgExpression* stride);
    SgExpression*  buildPntrArrRefExp_nfi(SgExpression* lhs, SgExpression* rhs);
+   SgExpression*  buildAggregateInitializer_nfi(SgExprListExp* initializers, SgType* type = nullptr);
    SgExpression*  buildAsteriskShapeExp_nfi();
    SgExpression*  buildNullExpression_nfi();
    SgExprListExp* buildExprListExp_nfi(const std::list<SgExpression*> &);


### PR DESCRIPTION
Edited traversal for ArrayConstructor and added traversals
for AcSpec and AcValue in sage-build.h and sage-build.cc,
and added wrapper function in sage-tree-builder to
implement array declarations and array assignments
with an ArrayConstructor.