### PR TITLE
(Fortran) Implement basic print statement

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
@@ -1372,53 +1372,59 @@ void Build(const parser::PrintStmt&x, T* scope)
    std::cout << "Rose::builder::Build(PrintStmt)\n";
 #endif
 
-   Build(std::get<0>(x.t), scope);   // Format
-   Build(std::get<1>(x.t), scope);   // OutputItem
+   std::list<SgExpression*> output_item_list;
+
+   SgExpression* format = nullptr;
+
+   Build(std::get<0>(x.t), format);           // Format
+   Build(std::get<1>(x.t), output_item_list); // std::list<OutputItem>
+
+   SgPrintStatement* print_stmt = nullptr;
+
+   builder.Enter(print_stmt, format, output_item_list);
+   builder.Leave(print_stmt);
 }
 
-template<typename T>
-void Build(const parser::Format&x, T* scope)
+void Build(const parser::Format&x, SgExpression* &format)
 {
 #if PRINT_FLANG_TRAVERSAL
    std::cout << "Rose::builder::Build(Format)\n";
 #endif
 
-   //   auto FormatVisitor = [&] (const auto &y) { Build(y, scope); };
-   //   std::visit(FormatVisitor, x.u);   // DefaultCharExpr, Label, Star
+   auto FormatVisitor = [&] (const auto &y) { Build(y, format); };
+   std::visit(FormatVisitor, x.u);   // DefaultCharExpr, Label, Star
 }
 
-template<typename T>
-void Build(const parser::DefaultCharExpr&x, T* scope)
+void Build(const parser::DefaultCharExpr&x, SgExpression* &expr)
 {
 #if PRINT_FLANG_TRAVERSAL
    std::cout << "Rose::builder::Build(DefaultCharExpr)\n";
 #endif
 }
 
-template<typename T>
-void Build(const parser::Label&x, T* scope)
+void Build(const parser::Label&x, SgExpression* &expr)
 {
 #if PRINT_FLANG_TRAVERSAL
    std::cout << "Rose::builder::Build(Label)\n";
 #endif
 }
 
-template<typename T>
-void Build(const parser::Star&x, T* scope)
+void Build(const parser::Star&x, SgExpression* &expr)
 {
 #if PRINT_FLANG_TRAVERSAL
    std::cout << "Rose::builder::Build(Star)\n";
 #endif
+
+   expr = SageBuilderCpp17::buildAsteriskShapeExp_nfi();
 }
 
-template<typename T>
-void Build(const parser::OutputItem&x, T* scope)
+void Build(const parser::OutputItem&x, SgExpression* &expr)
 {
 #if PRINT_FLANG_TRAVERSAL
    std::cout << "Rose::builder::Build(OutputItem)\n";
 #endif
 
-   SgExpression* expr = nullptr;
+   expr = nullptr;
 
    std::visit(
       common::visitors{

--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
@@ -155,11 +155,11 @@ template<typename T> void Build(const Fortran::parser::             OpenStmt &x,
 template<typename T> void Build(const Fortran::parser::PointerAssignmentStmt &x, T* scope);
 template<typename T> void Build(const Fortran::parser::            PrintStmt &x, T* scope);
 
-template<typename T> void Build(const Fortran::parser::               Format &x, T* scope);
-template<typename T> void Build(const Fortran::parser::      DefaultCharExpr &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                Label &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                 Star &x, T* scope);
-template<typename T> void Build(const Fortran::parser::           OutputItem &x, T* scope);
+void Build(const Fortran::parser::               Format &x, SgExpression* &expr);
+void Build(const Fortran::parser::      DefaultCharExpr &x, SgExpression* &expr);
+void Build(const Fortran::parser::                Label &x, SgExpression* &expr);
+void Build(const Fortran::parser::                 Star &x, SgExpression* &expr);
+void Build(const Fortran::parser::           OutputItem &x, SgExpression* &expr);
 template<typename T> void Build(const Fortran::parser::      OutputImpliedDo &x, T* scope);
 
 template<typename T> void Build(const Fortran::parser::             ReadStmt &x, T* scope);

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
@@ -690,6 +690,32 @@ Leave(SgDefaultOptionStmt* default_option_stmt)
 }
 
 void SageTreeBuilder::
+Enter(SgPrintStatement* &print_stmt, SgExpression* format, std::list<SgExpression*> &expr_list)
+{
+   mlog[TRACE] << "SageTreeBuilder::Enter(SgPrintStmt* &, ...) \n";
+
+   ROSE_ASSERT(format);
+
+   print_stmt = new SgPrintStatement();
+   ROSE_ASSERT(print_stmt);
+   SageInterface::setSourcePosition(print_stmt);
+
+   print_stmt->set_format(format);
+
+   SgExprListExp* io_stmt_list = SageBuilderCpp17::buildExprListExp_nfi(expr_list);
+   print_stmt->set_io_stmt_list(io_stmt_list);
+}
+
+void SageTreeBuilder::
+Leave(SgPrintStatement* print_stmt)
+{
+   mlog[TRACE] << "SageTreeBuilder::Leave(SgPrintStmt*, ...) \n";
+   ROSE_ASSERT(print_stmt);
+
+   SageInterface::appendStatement(print_stmt, SageBuilder::topScopeStack());
+}
+
+void SageTreeBuilder::
 Enter(SgWhileStmt* &while_stmt, SgExpression* condition)
 {
    mlog[TRACE] << "SageTreeBuilder::Enter(SgWhileStmt* &, ...) \n";

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
@@ -28,6 +28,7 @@ class SgIfStmt;
 class SgInitializedName;
 class SgLocatedNode;
 class SgNamespaceDeclarationStatement;
+class SgPrintStatement;
 class SgProcessControlStatement;
 class SgProgramHeaderStatement;
 class SgScopeStatement;
@@ -155,6 +156,9 @@ public:
 
    void Enter(SgDefaultOptionStmt* &);
    void Leave(SgDefaultOptionStmt*);
+
+   void Enter(SgPrintStatement* &, SgExpression*, std::list<SgExpression*> &);
+   void Leave(SgPrintStatement*);
 
    void Enter(SgWhileStmt* &, SgExpression*);
    void Leave(SgWhileStmt*, bool has_end_do_stmt=false);


### PR DESCRIPTION
Edited traversal in sage-build.h and sage-build.cc
for PrintStmt, Format, DefaultCharExpr, Label,
Star, and OutputItem to implement print statement.

Added a SageTreeBuilder function Enter() and Leave()
to build the SgPrintStatement node.