### PR TITLE
(Fortran) Implement type declarations with kind

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
@@ -804,6 +804,20 @@ void Build(const parser::AttrSpec &x, T* scope)
    std::visit(AttrSpecVisitor, x.u);
 }
 
+void Build(const parser::KindSelector &x, SgExpression* &expr)
+{
+#if PRINT_FLANG_TRAVERSAL
+   std::cout << "Rose::builder::Build(KindSelector)\n";
+#endif
+
+   std::visit(
+      common::visitors{
+         [&] (const parser::ScalarIntConstantExpr  &y) { Build(y.thing.thing, expr); },
+         [&] (const parser::KindSelector::StarSize &y) { ; },
+      },
+      x.u);
+}
+
 void Build(const parser::IntrinsicTypeSpec &x, SgType* &type)
 {
 #if PRINT_FLANG_TRAVERSAL
@@ -821,7 +835,13 @@ void Build(const parser::IntegerTypeSpec &x, SgType* &type)
    std::cout << "Rose::builder::Build(IntegerTypeSpec)\n";
 #endif
 
-   type = SageBuilderCpp17::buildIntType();
+   if (auto & kind = x.v) {   // std::optional<KindSelector>
+      SgExpression* kind_expr = nullptr;
+      Build(kind.value(), kind_expr);
+      type = SageBuilderCpp17::buildIntType(kind_expr);
+   } else {
+      type = SageBuilderCpp17::buildIntType();
+   }
 }
 
 void Build(const parser::IntrinsicTypeSpec::Real &x, SgType* &type)
@@ -830,7 +850,13 @@ void Build(const parser::IntrinsicTypeSpec::Real &x, SgType* &type)
    std::cout << "Rose::builder::Build(Real)\n";
 #endif
 
-   type = SageBuilderCpp17::buildFloatType();
+   if (auto & kind = x.kind) {   // std::optional<KindSelector>
+      SgExpression* kind_expr = nullptr;
+      Build(kind.value(), kind_expr);
+      type = SageBuilderCpp17::buildFloatType(kind_expr);
+   } else {
+      type = SageBuilderCpp17::buildFloatType();
+   }
 }
 
 void Build(const parser::IntrinsicTypeSpec::DoublePrecision &x, SgType* &type)
@@ -874,7 +900,13 @@ void Build(const parser::IntrinsicTypeSpec::Logical &x, SgType* &type)
    std::cout << "Rose::builder::Build(Logical)\n";
 #endif
 
-   type = SageBuilderCpp17::buildBoolType();
+   if (auto & kind = x.kind) {   // std::optional<KindSelector>
+      SgExpression* kind_expr = nullptr;
+      Build(kind.value(), kind_expr);
+      type = SageBuilderCpp17::buildBoolType(kind_expr);
+   } else {
+      type = SageBuilderCpp17::buildBoolType();
+   }
 }
 
 void Build(const parser::IntrinsicTypeSpec::DoubleComplex &x, SgType* &type)

--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
@@ -93,6 +93,7 @@ void Build(const Fortran::parser::             ArraySpec &x, SgType* &type, SgTy
 template<typename T> void Build(const Fortran::parser::           CoarraySpec &x, T* scope);
 void Build(const Fortran::parser::            CharLength &x, SgExpression* &);
 void Build(const Fortran::parser::        Initialization &x, SgExpression* &);
+void Build(const Fortran::parser::          KindSelector &x, SgExpression* &);
 void Build(const Fortran::parser::     IntrinsicTypeSpec &x,       SgType* &);
 void Build(const Fortran::parser::       IntegerTypeSpec &x,       SgType* &);
 

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
@@ -1117,6 +1117,21 @@ SgType* buildComplexType(SgType* base_type)
    return SageBuilder::buildComplexType(base_type);
 }
 
+SgType* buildBoolType(SgExpression* kind_expr)
+{
+   return SageBuilder::buildBoolType(kind_expr);
+}
+
+SgType* buildIntType(SgExpression* kind_expr)
+{
+   return SageBuilder::buildIntType(kind_expr);
+}
+
+SgType* buildFloatType(SgExpression* kind_expr)
+{
+   return SageBuilder::buildFloatType(kind_expr);
+}
+
 SgType* buildStringType(SgExpression* stringLengthExpression)
 {
    return SageBuilder::buildStringType(stringLengthExpression);

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
@@ -219,6 +219,9 @@ namespace SageBuilderCpp17 {
    SgType* buildCharType();
    SgType* buildDoubleType();
    SgType* buildComplexType(SgType* base_type = nullptr);
+   SgType* buildBoolType(SgExpression* kind_expr);
+   SgType* buildIntType(SgExpression* kind_expr);
+   SgType* buildFloatType(SgExpression* kind_expr);
    SgType* buildStringType(SgExpression* stringLengthExpression);
    SgType* buildArrayType(SgType* base_type, std::list<SgExpression*> &explicit_shape_list);
 


### PR DESCRIPTION
Edited traversals for IntegerTypeSpec, IntrinsicTypeSpec::Real,
and IntrinsicTypeSpec::Literal to implement types with kind. Also
added necessary wrapper functions in SageTreeBuilder.