### PR TITLE
(Fortran) Add corresponding enums for AttrSpec

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
@@ -9,6 +9,8 @@
 #include <iostream>
 #include <typeinfo>
 
+#include "../Experimental_General_Language_Support/general_language_translation.h"
+
 // WARNING: This file has been designed to compile with -std=c++17
 // This limits the use of ROSE header files at the moment.
 //
@@ -95,7 +97,7 @@ void Build(const Fortran::parser::DeclarationTypeSpec::   Record&x, SgType* &);
 void Build(const Fortran::parser::       DerivedTypeSpec &x,                      SgType* &);
 void Build(const Fortran::parser::            EntityDecl &x, std::string &, SgExpression* &, SgType* &, SgType *);
 void Build(const std::list<Fortran::parser:: EntityDecl> &x, std::string &, SgExpression* &, SgType* &, SgType *);
-template<typename T> void Build(const Fortran::parser::              AttrSpec &x, T* scope);
+void Build(const Fortran::parser::              AttrSpec &x, LanguageTranslation::ExpressionKind &modifier_enum);
 void Build(const Fortran::parser::             ArraySpec &x, SgType* &type, SgType* base_type);
 template<typename T> void Build(const Fortran::parser::           CoarraySpec &x, T* scope);
 void Build(const Fortran::parser::            CharLength &x, SgExpression* &);
@@ -278,22 +280,9 @@ template<typename T> void Build(const Fortran::parser:: OpenMPDeclarativeConstru
 template<typename T> void Build(const Fortran::parser::OpenACCDeclarativeConstruct&x, T* scope);
 
 // AttrSpec
-template<typename T> void Build(const Fortran::parser::               AccessSpec &x, T* scope);
-template<typename T> void Build(const Fortran::parser::              Allocatable &x, T* scope);
-template<typename T> void Build(const Fortran::parser::             Asynchronous &x, T* scope);
-template<typename T> void Build(const Fortran::parser::               Contiguous &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                 External &x, T* scope);
-template<typename T> void Build(const Fortran::parser::               IntentSpec &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                Intrinsic &x, T* scope);
-template<typename T> void Build(const Fortran::parser::      LanguageBindingSpec &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                 Optional &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                Parameter &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                  Pointer &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                Protected &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                     Save &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                   Target &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                    Value &x, T* scope);
-template<typename T> void Build(const Fortran::parser::                 Volatile &x, T* scope);
+void Build(const Fortran::parser::         AccessSpec &x, LanguageTranslation::ExpressionKind &modifier_enum);
+void Build(const Fortran::parser::         IntentSpec &x, LanguageTranslation::ExpressionKind &modifier_enum);
+void Build(const Fortran::parser::LanguageBindingSpec &x, LanguageTranslation::ExpressionKind &modifier_enum);
 
 
 // Traversal of needed STL template classes (optional, list, tuple, variant)                                                                
@@ -318,6 +307,19 @@ template<typename LT, typename T> void Build(const std::list<LT> &x, std::list<T
       T* rose_node = nullptr;
       Build(elem, rose_node);
       rose_node_list.push_back(rose_node);
+   }
+}
+
+template<typename LT, typename T> void Build(const std::list<LT> &x, std::list<T> &list)
+{
+#if PRINT_FLANG_TRAVERSAL
+   std::cout << "Rose::builder::Build(std::list) for LT* node building a list of T\n";
+#endif
+
+   for (const auto &elem : x) {
+      T node;
+      Build(elem, node);
+      list.push_back(node);
    }
 }
 


### PR DESCRIPTION
Edited traversal for AttrSpec, added LanguageTranslation::ExpressionKind
enums for Allocatable, Asynchronous, Contiguous, External, Intrinsic,
Optional, Pointer, Protected, Save, Target, Value, Volatile, Public,
Private, In, Out, InOut.