### PR TITLE
(Fortran) Implement multi variable declarations

### DIFF
--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.cc
@@ -1017,16 +1017,13 @@ void Build(const parser::TypeDeclarationStmt &x, T* scope)
    SgExpression* init = nullptr;
    std::list<LanguageTranslation::ExpressionKind> modifier_enum_list;
    std::string name{};
+   std::list<EntityDeclTuple> init_info;
 
    Build(std::get<0>(x.t), base_type);                    // DeclarationTypeSpec
    Build(std::get<1>(x.t), modifier_enum_list);           // std::list<AttrSpec>
-   Build(std::get<2>(x.t), name, init, type, base_type);  // std::list<EntityDecl>
+   Build(std::get<2>(x.t), init_info, base_type);         // std::list<EntityDecl>
 
-   if (!type) {
-      type = base_type;
-   }
-
-   builder.Enter(var_decl, name, type, init);
+   builder.Enter(var_decl, base_type, init_info);
    builder.Leave(var_decl, modifier_enum_list);
 }
 
@@ -1316,15 +1313,21 @@ void Build(const parser::TypeParamValue &x, SgExpression* &expr)
       },
       x.u);
 }
-
-void Build(const std::list<Fortran::parser::EntityDecl> &x, std::string &name, SgExpression* &init, SgType* &type, SgType* base_type)
+void Build(const std::list<Fortran::parser::EntityDecl> &x, std::list<EntityDeclTuple> &entity_decls, SgType* base_type)
 {
 #if PRINT_FLANG_TRAVERSAL
    std::cout << "Rose::builder::Build(std::list) for EntityDecl\n";
 #endif
 
    for (const auto &elem : x) {
+      EntityDeclTuple entity_decl;
+      std::string name;
+      SgType* type = nullptr;
+      SgExpression* init = nullptr;
+
       Build(elem, name, init, type, base_type);
+      entity_decl = std::make_tuple(name, type, init);
+      entity_decls.push_back(entity_decl);
    }
 }
 

--- a/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
+++ b/src/frontend/Experimental_Flang_ROSE_Connection/sage-build.h
@@ -25,6 +25,8 @@ class SgType;
 
 #define PRINT_FLANG_TRAVERSAL 0
 
+typedef std::tuple<std::string, SgType*, SgExpression*> EntityDeclTuple;
+
 namespace Rose::builder {
 
 // Converts parsed program to ROSE Sage nodes
@@ -106,7 +108,7 @@ void Build(const Fortran::parser::DeclarationTypeSpec::   Record&x, SgType* &);
 
 void Build(const Fortran::parser::       DerivedTypeSpec &x,                      SgType* &);
 void Build(const Fortran::parser::            EntityDecl &x, std::string &, SgExpression* &, SgType* &, SgType *);
-void Build(const std::list<Fortran::parser:: EntityDecl> &x, std::string &, SgExpression* &, SgType* &, SgType *);
+void Build(const std::list<Fortran::parser::EntityDecl>  &x, std::list<EntityDeclTuple> &entity_decls, SgType* base_type);
 void Build(const Fortran::parser::              AttrSpec &x, LanguageTranslation::ExpressionKind &modifier_enum);
 void Build(const Fortran::parser::             ArraySpec &x, SgType* &type, SgType* base_type);
 template<typename T> void Build(const Fortran::parser::           CoarraySpec &x, T* scope);

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.C
@@ -1337,6 +1337,43 @@ Enter(SgVariableDeclaration* &var_decl, const std::string &name, SgType* type, S
    SgInitializedName* var_defn = var_def->get_vardefn();
    ROSE_ASSERT(var_defn);
    ROSE_ASSERT(var_defn == init_name);
+}
+
+void SageTreeBuilder::
+Enter(SgVariableDeclaration* &var_decl, SgType* base_type, std::list<std::tuple<std::string, SgType*, SgExpression*>> &init_info)
+{
+   mlog[TRACE] << "SageTreeBuilder::Enter(SgVariableDeclaration* &, std::tuple<...>, ...) \n";
+
+   // Step through list of tuples to create the multi variable declaration
+   for (std::list<std::tuple<std::string, SgType*, SgExpression*>>::iterator it = init_info.begin(); it != init_info.end(); ++it) {
+      std::string name;
+      SgType* type;
+      SgExpression* init_expr;
+      std::tie(name, type, init_expr) = *it;
+
+      if (!type) {
+         type = base_type;
+      }
+
+      if (it == init_info.begin()) {   // On first pass, call Enter() to create variable declaration
+         Enter(var_decl, name, type, init_expr);
+      } else {                         // On later passes, create new initialized name and append to the var decl
+         SgAssignInitializer* init = nullptr;
+         if (init_expr) {
+            init = SageBuilder::buildAssignInitializer_nfi(init_expr, type);
+         }
+
+         SgInitializedName* init_name = SageBuilder::buildInitializedName(name, type, init);
+         var_decl->append_variable(init_name, init);
+         init_name->set_declptr(var_decl);
+      }
+   }
+}
+
+void SageTreeBuilder::
+Leave(SgVariableDeclaration* var_decl)
+{
+   mlog[TRACE] << "SageTreeBuilder::Leave(SgVariableDeclaration*) \n";
 
    SageInterface::appendStatement(var_decl, SageBuilder::topScopeStack());
 }
@@ -1367,12 +1404,8 @@ Leave(SgVariableDeclaration* var_decl, std::list<LanguageTranslation::Expression
          default: break;
        }
    }
-}
 
-void SageTreeBuilder::
-Leave(SgVariableDeclaration* var_decl)
-{
-   mlog[TRACE] << "SageTreeBuilder::Leave(SgVariableDeclaration*) \n";
+   Leave(var_decl);
 }
 
 void SageTreeBuilder::

--- a/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
+++ b/src/frontend/Experimental_General_Language_Support/sage-tree-builder.h
@@ -130,9 +130,9 @@ public:
    void Leave(SgDerivedTypeStatement*);
 
    void Enter(SgVariableDeclaration* &, const std::string &, SgType*, SgExpression*);
-   void Leave(SgVariableDeclaration*, std::list<LanguageTranslation::ExpressionKind> &);
+   void Enter(SgVariableDeclaration* &, SgType*, std::list<std::tuple<std::string, SgType*, SgExpression*>> &);
    void Leave(SgVariableDeclaration*);
-
+   void Leave(SgVariableDeclaration*, std::list<LanguageTranslation::ExpressionKind> &);
 
    void Enter(SgEnumDeclaration* &, const std::string &);
    void Leave(SgEnumDeclaration*);


### PR DESCRIPTION
In sage-build.cc, I edited the traversal for TypeDeclarationStmt and the
list of EntityDecls to implement multi variable declarations. I created
a tuple, called EntityDeclTuple to grab and pass the necessary
information, the name, type, and initializer.

In SageTreeBuilder, I added an overloaded Enter() function for SgVariableDeclaration
to unpack the EntityDeclTuple and create a  multi variable declaration.